### PR TITLE
Fix SolverParams order mismatch

### DIFF
--- a/tests/solver_test.cc
+++ b/tests/solver_test.cc
@@ -92,8 +92,8 @@ class SolverTest
         .static_preordering = std::get<5>(GetParam()),
         .dynamic_decomposition = std::get<6>(GetParam()),
         .monotonic_floor = std::get<7>(GetParam()),
-        .minimize_capacity = std::get<8>(GetParam()),
         .hatless_pruning = false,
+        .minimize_capacity = std::get<8>(GetParam()),
     };
   }
 };


### PR DESCRIPTION
This commit fixes a small issues in one of the solver_tests where the designator order for the field `minimize_capacity` did not match the declaration order in `SolverParams`. This would previously lead to a compiler error during building.