### PR TITLE
Fix log initialization and formatting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(minimalloc
 target_link_libraries(minimalloc
   absl::flags_parse
   absl::log
+  absl::log_initialize
   absl::statusor
 )
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -27,6 +27,8 @@ limitations under the License.
 
 #include "absl/flags/flag.h"
 #include "absl/flags/parse.h"
+#include "absl/log/globals.h"
+#include "absl/log/initialize.h"
 #include "absl/log/log.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/str_split.h"
@@ -118,6 +120,9 @@ void PrintSolution(const minimalloc::Problem& problem,
 
 // Solves a given problem using the Solver.
 int main(int argc, char* argv[]) {
+  absl::SetStderrThreshold(absl::LogSeverityAtLeast::kInfo);
+  absl::EnableLogPrefix(false);
+  absl::InitializeLog();
   absl::ParseCommandLine(argc, argv);
   minimalloc::SolverParams params = {
       .timeout = absl::GetFlag(FLAGS_timeout),


### PR DESCRIPTION
This commit fixes two small issues in the abseil logger. First, a call to the log initialization function was missing, which would lead to verbose warnings about uninitialized logging. Second, the formatting of the log messages would include a long prefix, which was not ideal, especially when running the benchmark script.